### PR TITLE
mediatek: apsoc: move early functions into assembly helpers

### DIFF
--- a/plat/mediatek/apsoc_common/bl2/bl2_plat_setup.c
+++ b/plat/mediatek/apsoc_common/bl2/bl2_plat_setup.c
@@ -395,10 +395,6 @@ void plat_flush_next_bl_params(void)
 	flush_bl_params_desc();
 }
 
-void platform_mem_init(void)
-{
-}
-
 void bl2_el3_early_platform_setup(u_register_t arg0, u_register_t arg1,
 				  u_register_t arg2, u_register_t arg3)
 {

--- a/plat/mediatek/mt7622/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7622/aarch64/plat_helpers.S
@@ -8,6 +8,7 @@
 #include <asm_macros.S>
 #include <mt7622_def.h>
 
+	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
 	.globl	platform_is_primary_cpu
@@ -17,6 +18,17 @@
 	.globl	plat_crash_console_flush
 	.globl	read_cpuectlr
 	.globl	write_cpuectlr
+
+	/* --------------------------------------------------------
+	 * void platform_mem_init (void);
+	 *
+	 * Any memory init, relocation to be done before the
+	 * platform boots. Called very early in the boot process.
+	 * --------------------------------------------------------
+	 */
+func platform_mem_init
+	ret
+endfunc platform_mem_init
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);

--- a/plat/mediatek/mt7622/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7622/aarch64/plat_helpers.S
@@ -11,7 +11,7 @@
 	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
-	.globl	platform_is_primary_cpu
+	.globl	plat_is_my_cpu_primary
 	.globl  plat_my_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
@@ -55,12 +55,13 @@ func write_cpuectlr
 	ret
 endfunc	write_cpuectlr
 
-func platform_is_primary_cpu
+func plat_is_my_cpu_primary
+	mrs	x0, mpidr_el1
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #MT7622_PRIMARY_CPU
 	cset	x0, eq
 	ret
-endfunc platform_is_primary_cpu
+endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
 	 * unsigned int plat_my_core_pos(void);

--- a/plat/mediatek/mt7622/bl2/bl2_plat_init.c
+++ b/plat/mediatek/mt7622/bl2/bl2_plat_init.c
@@ -31,11 +31,6 @@ void bl2_el3_plat_arch_setup(void)
 {
 }
 
-bool plat_is_my_cpu_primary(void)
-{
-	return true;
-}
-
 const struct initcall bl2_initcalls[] = {
 	INITCALL(plat_mt_cpuxgpt_init),
 	INITCALL(generic_delay_timer_init),

--- a/plat/mediatek/mt7629/aarch32/plat_helpers.S
+++ b/plat/mediatek/mt7629/aarch32/plat_helpers.S
@@ -10,6 +10,7 @@
 #include <mt7629_def.h>
 #include <pll.h>
 
+	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
 	.globl	plat_is_my_cpu_primary
@@ -18,6 +19,17 @@
 	.globl	plat_crash_console_putc
 	.globl	plat_crash_console_flush
 	.globl	plat_reset_handler
+
+	/* --------------------------------------------------------
+	 * void platform_mem_init (void);
+	 *
+	 * Any memory init, relocation to be done before the
+	 * platform boots. Called very early in the boot process.
+	 * --------------------------------------------------------
+	 */
+func platform_mem_init
+	bx	lr
+endfunc platform_mem_init
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);

--- a/plat/mediatek/mt7981/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7981/aarch64/plat_helpers.S
@@ -11,7 +11,7 @@
 	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
-	.globl	platform_is_primary_cpu
+	.globl	plat_is_my_cpu_primary
 	.globl  plat_my_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
@@ -55,12 +55,13 @@ func write_cpuectlr
 	ret
 endfunc	write_cpuectlr
 
-func platform_is_primary_cpu
+func plat_is_my_cpu_primary
+	mrs     x0, mpidr_el1
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #PRIMARY_CPU
 	cset	x0, eq
 	ret
-endfunc platform_is_primary_cpu
+endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
 	 * unsigned int plat_my_core_pos(void);

--- a/plat/mediatek/mt7981/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7981/aarch64/plat_helpers.S
@@ -8,6 +8,7 @@
 #include <asm_macros.S>
 #include <mt7981_def.h>
 
+	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
 	.globl	platform_is_primary_cpu
@@ -17,6 +18,17 @@
 	.globl	plat_crash_console_flush
 	.globl	read_cpuectlr
 	.globl	write_cpuectlr
+
+	/* --------------------------------------------------------
+	 * void platform_mem_init (void);
+	 *
+	 * Any memory init, relocation to be done before the
+	 * platform boots. Called very early in the boot process.
+	 * --------------------------------------------------------
+	 */
+func platform_mem_init
+	ret
+endfunc platform_mem_init
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);

--- a/plat/mediatek/mt7981/bl2/bl2_plat_init.c
+++ b/plat/mediatek/mt7981/bl2/bl2_plat_init.c
@@ -59,11 +59,6 @@ void bl2_el3_plat_arch_setup(void)
 {
 }
 
-bool plat_is_my_cpu_primary(void)
-{
-	return true;
-}
-
 const struct initcall bl2_initcalls[] = {
 	INITCALL(mtk_timer_init),
 	INITCALL(generic_delay_timer_init),

--- a/plat/mediatek/mt7986/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7986/aarch64/plat_helpers.S
@@ -11,7 +11,7 @@
 	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
-	.globl	platform_is_primary_cpu
+	.globl	plat_is_my_cpu_primary
 	.globl  plat_my_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
@@ -55,12 +55,13 @@ func write_cpuectlr
 	ret
 endfunc	write_cpuectlr
 
-func platform_is_primary_cpu
+func plat_is_my_cpu_primary
+	mrs     x0, mpidr_el1
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #PRIMARY_CPU
 	cset	x0, eq
 	ret
-endfunc platform_is_primary_cpu
+endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
 	 * unsigned int plat_my_core_pos(void);

--- a/plat/mediatek/mt7986/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7986/aarch64/plat_helpers.S
@@ -8,6 +8,7 @@
 #include <asm_macros.S>
 #include <mt7986_def.h>
 
+	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
 	.globl	platform_is_primary_cpu
@@ -17,6 +18,17 @@
 	.globl	plat_crash_console_flush
 	.globl	read_cpuectlr
 	.globl	write_cpuectlr
+
+	/* --------------------------------------------------------
+	 * void platform_mem_init (void);
+	 *
+	 * Any memory init, relocation to be done before the
+	 * platform boots. Called very early in the boot process.
+	 * --------------------------------------------------------
+	 */
+func platform_mem_init
+	ret
+endfunc platform_mem_init
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);

--- a/plat/mediatek/mt7986/bl2/bl2_plat_init.c
+++ b/plat/mediatek/mt7986/bl2/bl2_plat_init.c
@@ -83,11 +83,6 @@ void bl2_el3_plat_arch_setup(void)
 {
 }
 
-bool plat_is_my_cpu_primary(void)
-{
-	return true;
-}
-
 const struct initcall bl2_initcalls[] = {
 	INITCALL(mtk_timer_init),
 	INITCALL(generic_delay_timer_init),

--- a/plat/mediatek/mt7987/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7987/aarch64/plat_helpers.S
@@ -8,6 +8,7 @@
 #include <asm_macros.S>
 #include <mt7987_def.h>
 
+	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
 	.globl	platform_is_primary_cpu
@@ -17,6 +18,17 @@
 	.globl	plat_crash_console_flush
 	.globl	read_cpuectlr
 	.globl	write_cpuectlr
+
+	/* --------------------------------------------------------
+	 * void platform_mem_init (void);
+	 *
+	 * Any memory init, relocation to be done before the
+	 * platform boots. Called very early in the boot process.
+	 * --------------------------------------------------------
+	 */
+func platform_mem_init
+	ret
+endfunc platform_mem_init
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);

--- a/plat/mediatek/mt7987/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7987/aarch64/plat_helpers.S
@@ -11,7 +11,7 @@
 	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
-	.globl	platform_is_primary_cpu
+	.globl	plat_is_my_cpu_primary
 	.globl  plat_my_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
@@ -54,12 +54,13 @@ func write_cpuectlr
 	ret
 endfunc	write_cpuectlr
 
-func platform_is_primary_cpu
+func plat_is_my_cpu_primary
+	mrs     x0, mpidr_el1
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #PRIMARY_CPU
 	cset	x0, eq
 	ret
-endfunc platform_is_primary_cpu
+endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
 	 * unsigned int plat_my_core_pos(void);

--- a/plat/mediatek/mt7987/bl2/bl2_plat_init.c
+++ b/plat/mediatek/mt7987/bl2/bl2_plat_init.c
@@ -188,11 +188,6 @@ void bl2_el3_plat_arch_setup(void)
 	generic_delay_timer_init();
 }
 
-bool plat_is_my_cpu_primary(void)
-{
-	return true;
-}
-
 const struct initcall bl2_initcalls[] = {
 	INITCALL(mtk_wdt_init),
 	INITCALL(mtk_disable_PGD),

--- a/plat/mediatek/mt7988/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7988/aarch64/plat_helpers.S
@@ -8,6 +8,7 @@
 #include <asm_macros.S>
 #include <mt7988_def.h>
 
+	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
 	.globl	platform_is_primary_cpu
@@ -17,6 +18,17 @@
 	.globl	plat_crash_console_flush
 	.globl	read_cpuectlr
 	.globl	write_cpuectlr
+
+	/* --------------------------------------------------------
+	 * void platform_mem_init (void);
+	 *
+	 * Any memory init, relocation to be done before the
+	 * platform boots. Called very early in the boot process.
+	 * --------------------------------------------------------
+	 */
+func platform_mem_init
+	ret
+endfunc platform_mem_init
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);

--- a/plat/mediatek/mt7988/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt7988/aarch64/plat_helpers.S
@@ -11,7 +11,7 @@
 	.globl	platform_mem_init
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
-	.globl	platform_is_primary_cpu
+	.globl	plat_is_my_cpu_primary
 	.globl  plat_my_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
@@ -54,12 +54,13 @@ func write_cpuectlr
 	ret
 endfunc	write_cpuectlr
 
-func platform_is_primary_cpu
+func plat_is_my_cpu_primary
+	mrs     x0, mpidr_el1
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #PRIMARY_CPU
 	cset	x0, eq
 	ret
-endfunc platform_is_primary_cpu
+endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
 	 * unsigned int plat_my_core_pos(void);

--- a/plat/mediatek/mt7988/bl2/bl2_plat_init.c
+++ b/plat/mediatek/mt7988/bl2/bl2_plat_init.c
@@ -174,11 +174,6 @@ void bl2_el3_plat_arch_setup(void)
 	generic_delay_timer_init();
 }
 
-bool plat_is_my_cpu_primary(void)
-{
-	return true;
-}
-
 const struct initcall bl2_initcalls[] = {
 	INITCALL(mtk_wdt_init),
 	INITCALL(mtk_disable_PGD),


### PR DESCRIPTION
These functions are called before the C stack is set up, which resulted in hangs when TF‐A is compiled with `-fno-omit-frame-pointer`, as is now the default on several major Linux distributions.

See the commit messages for further details.