### PR TITLE
Customization of the MT7981 platform to match U6+ pinout and lower the

### DIFF
--- a/plat/mediatek/apsoc_common/bl2/bl2_boot_mmc.c
+++ b/plat/mediatek/apsoc_common/bl2/bl2_boot_mmc.c
@@ -7,21 +7,23 @@
 
 #include <errno.h>
 #include <inttypes.h>
+
 #include <common/debug.h>
 #include <common/tbbr/tbbr_img_def.h>
-#include <drivers/partition/partition.h>
-#include <drivers/partition/mbr.h>
-#include <drivers/io/io_driver.h>
 #include <drivers/io/io_block.h>
+#include <drivers/io/io_driver.h>
 #include <drivers/mmc.h>
-#include "bl2_plat_setup.h"
+#include <drivers/partition/mbr.h>
+#include <drivers/partition/partition.h>
 #include <mtk-sd.h>
+
+#include "bl2_plat_setup.h"
 #ifdef DUAL_FIP
 #include "bsp_conf.h"
 #include "dual_fip.h"
 #endif
 
-#define FIP_BOOT_OFFSET				0x100000
+#define FIP_BOOT_OFFSET 0x100000
 
 static size_t mmc_uda_read_blocks(int lba, uintptr_t buf, size_t size);
 
@@ -49,8 +51,9 @@ static io_block_spec_t mmc_dev_bkup_gpt_spec = {
 };
 
 #ifdef DUAL_FIP
-#define BSPCONF_ALIGNED_SIZE	\
-	((sizeof(struct mtk_bsp_conf_data) + MMC_BLOCK_SIZE - 1) & ~(MMC_BLOCK_SIZE - 1))
+#define BSPCONF_ALIGNED_SIZE                                       \
+	((sizeof(struct mtk_bsp_conf_data) + MMC_BLOCK_SIZE - 1) & \
+	 ~(MMC_BLOCK_SIZE - 1))
 
 #ifdef FIP_IN_BOOT0
 static size_t mmc_boot0_read_blocks(int lba, uintptr_t buf, size_t size);
@@ -252,8 +255,7 @@ static void mtk_load_bsp_conf_mmc(uintptr_t dev_handle)
 	mmc_dev_bootconf1_spec.offset = entry->start;
 	mmc_dev_bootconf1_spec.length = BSPCONF_ALIGNED_SIZE;
 
-	ret = mtk_dev_read_spec(dev_handle,
-				(uintptr_t)&mmc_dev_bootconf1_spec,
+	ret = mtk_dev_read_spec(dev_handle, (uintptr_t)&mmc_dev_bootconf1_spec,
 				&buf, 0, sizeof(buf), MTK_BSP_CONF_NAME "1");
 	if (!ret) {
 		memcpy(&bc1, buf, sizeof(bc1));
@@ -271,8 +273,7 @@ static void mtk_load_bsp_conf_mmc(uintptr_t dev_handle)
 	mmc_dev_bootconf2_spec.offset -= BSPCONF_ALIGNED_SIZE;
 	mmc_dev_bootconf2_spec.length = BSPCONF_ALIGNED_SIZE;
 
-	ret = mtk_dev_read_spec(dev_handle,
-				(uintptr_t)&mmc_dev_bootconf2_spec,
+	ret = mtk_dev_read_spec(dev_handle, (uintptr_t)&mmc_dev_bootconf2_spec,
 				&buf, 0, sizeof(buf), MTK_BSP_CONF_NAME "2");
 	if (!ret) {
 		memcpy(&bc2, buf, sizeof(bc2));
@@ -357,8 +358,8 @@ int mtk_dual_fip_image_setup(uintptr_t *dev_handle, uintptr_t *image_spec)
 	mmc_dev_fip_spec.offset = FIP_BOOT_OFFSET;
 	mmc_dev_fip_spec.length = mmc_boot_part_size() - FIP_BOOT_OFFSET;
 
-	NOTICE("FIP in BOOT0 at 0x%zx, size 0x%zx\n",
-	       mmc_dev_fip_spec.offset, mmc_dev_fip_spec.length);
+	NOTICE("FIP in BOOT0 at 0x%zx, size 0x%zx\n", mmc_dev_fip_spec.offset,
+	       mmc_dev_fip_spec.length);
 
 	mmc_dev_handles[0] = mmc_dev_boot0_handle;
 #else
@@ -373,8 +374,8 @@ int mtk_dual_fip_image_setup(uintptr_t *dev_handle, uintptr_t *image_spec)
 	mmc_dev_fip2_spec.offset = FIP_BOOT_OFFSET;
 	mmc_dev_fip2_spec.length = mmc_boot_part_size() - FIP_BOOT_OFFSET;
 
-	NOTICE("FIP2 in BOOT1 at 0x%zx, size 0x%zx\n",
-	       mmc_dev_fip2_spec.offset, mmc_dev_fip2_spec.length);
+	NOTICE("FIP2 in BOOT1 at 0x%zx, size 0x%zx\n", mmc_dev_fip2_spec.offset,
+	       mmc_dev_fip2_spec.length);
 
 	mmc_dev_handles[1] = mmc_dev_boot1_handle;
 #else
@@ -422,7 +423,7 @@ int mtk_fip_image_setup(uintptr_t *dev_handle, uintptr_t *image_spec)
 	return mtk_dual_fip_image_setup(dev_handle, image_spec);
 #endif
 
-	*dev_handle = fill_io_block_spec_gpt(&mmc_dev_fip_spec, "fip");
+	*dev_handle = fill_io_block_spec_gpt(&mmc_dev_fip_spec, "u-boot");
 	if (!*dev_handle)
 		return -ENOENT;
 
@@ -442,10 +443,10 @@ void plat_patch_mbr_header(void *mbr)
 	mbr_entry = (mbr_entry_t *)(mbr + MBR_PRIMARY_ENTRY_OFFSET);
 	memcpy(&num, &mbr_entry->sector_nums, sizeof(uint32_t));
 	if (num != num_sectors) {
-		INFO("Patching MBR num of sectors: 0x%x -> 0x%x\n",
-		     num, num_sectors - 1);
+		INFO("Patching MBR num of sectors: 0x%x -> 0x%x\n", num,
+		     num_sectors - 1);
 
-		num = num_sectors -1;
+		num = num_sectors - 1;
 		memcpy(&mbr_entry->sector_nums, &num, sizeof(uint32_t));
 	}
 }

--- a/plat/mediatek/mt7981/bl2/bl2_dev_mmc.c
+++ b/plat/mediatek/mt7981/bl2/bl2_dev_mmc.c
@@ -5,11 +5,21 @@
  */
 
 #include <assert.h>
+
+#include <platform_def.h>
+
 #include <drivers/mmc.h>
 #include <drivers/mmc/mtk-sd.h>
 #include <lib/mmio.h>
 #include <mt7981_gpio.h>
-#include <platform_def.h>
+
+#define MSDC0_GPIO_BASE 0x11c10000
+#define MSDC0_GPIO_IES_CFG0 (MSDC0_GPIO_BASE + 0x20)
+#define MSDC0_GPIO_SMT_CFG0 (MSDC0_GPIO_BASE + 0x90)
+#define MSDC0_GPIO_R0_CFG0 (MSDC0_GPIO_BASE + 0x40)
+#define MSDC0_GPIO_R1_CFG0 (MSDC0_GPIO_BASE + 0x50)
+#define MSDC0_GPIO_DRV_CFG0 (MSDC0_GPIO_BASE + 0x00)
+#define MSDC0_GPIO_DRV_CFG1 (MSDC0_GPIO_BASE + 0x10)
 
 struct msdc_gpio_mux_info {
 	const uint32_t *pins;
@@ -25,20 +35,19 @@ static const struct msdc_compatible mt7981_msdc0_compat = {
 	.data_tune = true,
 	.busy_check = true,
 	.stop_clk_fix = true,
+	.enhance_rx = true,
 };
 
 static const uint32_t msdc0_pins[] = {
-	GPIO15, GPIO16, GPIO17, GPIO18,
-	GPIO19, GPIO20, GPIO21, GPIO22,
-	GPIO23, GPIO24, GPIO25,
+	GPIO15, GPIO16, GPIO17, GPIO18, GPIO19, GPIO20,
+	GPIO21, GPIO22, GPIO23, GPIO24, GPIO25,
 };
 
 static const uint32_t msdc0_pupd[] = {
-        MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP,
-        MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP,
-        MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_DOWN,
+	MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP,
+	MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP,
+	MT_GPIO_PULL_UP, MT_GPIO_PULL_UP, MT_GPIO_PULL_UP,
 };
-
 
 static const struct msdc_gpio_mux_info msdc0_pinmux = {
 	.pins = msdc0_pins,
@@ -55,62 +64,58 @@ static const struct mt7981_msdc_conf {
 	uint32_t src_clk;
 	const struct msdc_compatible *dev_comp;
 	const struct msdc_gpio_mux_info *pinmux;
-} mt7981_msdc[] = {
-	{
-		.base = MSDC0_BASE,
-		.top_base = MSDC0_TOP_BASE,
-		.bus_width = MMC_BUS_WIDTH_8,
-		.type = MMC_IS_EMMC,
-		.src_clk = 40000000,
-		.dev_comp = &mt7981_msdc0_compat,
-		.pinmux = &msdc0_pinmux,
-	},
-	{
-		.base = MSDC0_BASE,
-		.top_base = MSDC0_TOP_BASE,
-		.bus_width = MMC_BUS_WIDTH_4,
-		.type = MMC_IS_SD,
-		.src_clk = 40000000,
-		.dev_comp = &mt7981_msdc0_compat,
-		.pinmux = &msdc0_pinmux,
-	}
-};
+} mt7981_msdc[] = { {
+			    .base = MSDC0_BASE,
+			    .top_base = MSDC0_TOP_BASE,
+			    .bus_width = MMC_BUS_WIDTH_1,
+			    .type = MMC_IS_EMMC,
+			    .src_clk = 40000000,
+			    .dev_comp = &mt7981_msdc0_compat,
+			    .pinmux = &msdc0_pinmux,
+		    },
+		    {
+			    .base = MSDC0_BASE,
+			    .top_base = MSDC0_TOP_BASE,
+			    .bus_width = MMC_BUS_WIDTH_1,
+			    .type = MMC_IS_SD,
+			    .src_clk = 40000000,
+			    .dev_comp = &mt7981_msdc0_compat,
+			    .pinmux = &msdc0_pinmux,
+		    } };
 
 static void mmc_gpio_setup(void)
 {
+	/* GPIO IES */
+	mmio_setbits_32(MSDC0_GPIO_IES_CFG0, 0x7ff << EMMC45_GPIO_IES_S);
 
-       /* GPIO IES */
-       mmio_clrsetbits_32(MSDC_GPIO_IES_CFG0,
-		0x7ff << EMMC45_GPIO_IES_S, 0x7ff << EMMC45_GPIO_IES_S);
+	/* GPIO SMT */
+	mmio_setbits_32(MSDC0_GPIO_SMT_CFG0, 0x7ff << EMMC45_GPIO_SMT_S);
 
-       /* GPIO SMT */
-       mmio_clrsetbits_32(MSDC_GPIO_SMT_CFG0,
-		0x7ff << EMMC45_GPIO_SMT_S, 0x7ff << EMMC45_GPIO_SMT_S);
+	/* GPIO R0 */
+	mmio_clrsetbits_32(MSDC0_GPIO_R0_CFG0, 0x7ff << EMMC45_GPIO_R0_S,
+			   0x6ff << EMMC45_GPIO_R0_S);
 
-       /* GPIO R0 */
-       mmio_clrsetbits_32(MSDC_GPIO_R0_CFG0,
-		0x7ff << EMMC45_GPIO_R0_S, 0x6ff << EMMC45_GPIO_R0_S);
+	/* GPIO R1 */
+	mmio_clrsetbits_32(MSDC0_GPIO_R1_CFG0, 0x7ff << EMMC45_GPIO_R1_S,
+			   0x100 << EMMC45_GPIO_R1_S);
 
-       /* GPIO R1 */
-       mmio_clrsetbits_32(MSDC_GPIO_R1_CFG0,
-		0x7ff << EMMC45_GPIO_R1_S, 0x100 << EMMC45_GPIO_R1_S);
-
-        /* GPIO driving */
-       mmio_clrsetbits_32(MSDC_GPIO_DRV_CFG0,
+	/* GPIO driving */
+	mmio_clrsetbits_32(
+		MSDC0_GPIO_DRV_CFG0,
 		0x7 << EMMC45_RSTB_DRV_S | 0x7 << EMMC45_DAT0_DRV_S |
-		0x7 << EMMC45_DAT3_DRV_S | 0x7 << EMMC45_DAT4_DRV_S |
-		0x7 << EMMC45_DAT2_DRV_S | 0x7 << EMMC45_DAT1_DRV_S |
-		0x7 << EMMC45_DAT5_DRV_S | 0x7 << EMMC45_DAT6_DRV_S |
-		0x7 << EMMC45_CLK_DRV_S  | 0x7 << EMMC45_CMD_DRV_S,
+			0x7 << EMMC45_DAT3_DRV_S | 0x7 << EMMC45_DAT4_DRV_S |
+			0x7 << EMMC45_DAT2_DRV_S | 0x7 << EMMC45_DAT1_DRV_S |
+			0x7 << EMMC45_DAT5_DRV_S | 0x7 << EMMC45_DAT6_DRV_S |
+			0x7 << EMMC45_CLK_DRV_S | 0x7 << EMMC45_CMD_DRV_S,
 
 		0x1 << EMMC45_RSTB_DRV_S | 0x1 << EMMC45_DAT0_DRV_S |
-		0x1 << EMMC45_DAT3_DRV_S | 0x1 << EMMC45_DAT4_DRV_S |
-		0x1 << EMMC45_DAT2_DRV_S | 0x1 << EMMC45_DAT1_DRV_S |
-		0x1 << EMMC45_DAT5_DRV_S | 0x1 << EMMC45_DAT6_DRV_S |
-		0x1 << EMMC45_CLK_DRV_S  | 0x1 << EMMC45_CMD_DRV_S);
+			0x1 << EMMC45_DAT3_DRV_S | 0x1 << EMMC45_DAT4_DRV_S |
+			0x1 << EMMC45_DAT2_DRV_S | 0x1 << EMMC45_DAT1_DRV_S |
+			0x1 << EMMC45_DAT5_DRV_S | 0x1 << EMMC45_DAT6_DRV_S |
+			0x1 << EMMC45_CLK_DRV_S | 0x1 << EMMC45_CMD_DRV_S);
 
-       mmio_clrsetbits_32(MSDC_GPIO_DRV_CFG1,
-		0x7 << EMMC45_DAT7_DRV_S, 0x1 << EMMC45_DAT7_DRV_S);
+	mmio_clrsetbits_32(MSDC0_GPIO_DRV_CFG1, 0x7 << EMMC45_DAT7_DRV_S,
+			   0x1 << EMMC45_DAT7_DRV_S);
 }
 
 int mtk_plat_mmc_setup(uint32_t *num_sectors)
@@ -125,8 +130,8 @@ int mtk_plat_mmc_setup(uint32_t *num_sectors)
 
 	mmc_gpio_setup();
 
-	mtk_mmc_init(conf->base, conf->top_base, conf->dev_comp,
-		     conf->src_clk, conf->type, conf->bus_width);
+	mtk_mmc_init(conf->base, conf->top_base, conf->dev_comp, conf->src_clk,
+		     conf->type, conf->bus_width);
 
 	if (num_sectors)
 		*num_sectors = mtk_mmc_block_count();


### PR DESCRIPTION
Hacking BL2 boot to slow down MMC interfacing. Helps with bricked U6+ devices that show errors similar to this:

ERROR:   MSDC: CRC error occured while reading data with cmd=8, arg=0x0
ERROR:   MSDC: CRC error occured while reading data with cmd=17, arg=0x3400
ERROR:   MSDC: CRC error occured while reading data with cmd=17, arg=0x3400
ERROR:   BL2: Failed to load image id 3 (-5)