### PR TITLE
mediatek: mt7622: move PMIC init before PLL/DRAM stage

### DIFF
--- a/plat/mediatek/mt7622/bl2/bl2_plat_init.c
+++ b/plat/mediatek/mt7622/bl2/bl2_plat_init.c
@@ -37,11 +37,11 @@ const struct initcall bl2_initcalls[] = {
 	INITCALL(mtk_wdt_print_status),
 	INITCALL(mtk_print_cpu),
 	INITCALL(mtk_pin_init),
+	INITCALL(mtk_pwrap_init),
+	INITCALL(mtk_pmic_init),
 #ifndef IMAGE_BL2PL
 	INITCALL(mtk_pll_init),
 #endif
-	INITCALL(mtk_pwrap_init),
-	INITCALL(mtk_pmic_init),
 	INITCALL(mtk_mem_init),
 	INITCALL(mtk_wdt_init),
 


### PR DESCRIPTION
When using cpufreq on the MT7622 it can happen that Vcore is lowered at the time the kernel triggers a reboot. In this case, bl2 hangs in DRAM calibration for ever:
```
NOTICE:  BL2: v2.14.0(release):OpenWrt v2026.01.23~e06f2586-1 (mt7622-snand-ubi-2ddr)
NOTICE:  BL2: Built : 16:53:29, Apr 16 2026
NOTICE:  WDT: [40000000] Software reset (reboot)
NOTICE:  CPU: MT7622
```
This can easily be fixed by moving PMIC init to happen earlier, allowing for reliable reboot independently of the previous Vcore.