### PR TITLE
fix(mediatek): keep spi-nand nb_planes from probe

### DIFF
--- a/plat/mediatek/apsoc_common/drivers/spi_nand/mtk_spi_nand.c
+++ b/plat/mediatek/apsoc_common/drivers/spi_nand/mtk_spi_nand.c
@@ -936,7 +936,6 @@ success:
 
 	spinand_dev.nand_dev->mtd_block_is_bad = spi_nand_mtd_block_is_bad;
 	spinand_dev.nand_dev->mtd_read_page = spi_nand_mtd_read_page;
-	spinand_dev.nand_dev->nb_planes = 1;
 
 	zeromem(&spinand_dev.spi_read_cache_op, sizeof(struct spi_mem_op));
 	spinand_dev.spi_read_cache_op.cmd.opcode = SPI_NAND_OP_READ_FROM_CACHE_4X;


### PR DESCRIPTION
spi_nand_init() in mtk_spi_nand.c unconditionally reset nand_dev->nb_planes to 1 right after the success: label, throwing away the value that spi_nand_set_data_via_{id,pp,casn}() had just filled in from the parameter page / CASN / ID-table descriptor.

spi_nand_read_from_cache() uses nb_planes > 1 to OR the plane-select bit into the column address of READ FROM CACHE for odd-numbered blocks. With nb_planes forced to 1, every read from plane 1 of a 2-plane chip (e.g. Micron MT29F2G01ABAGD and its drop-in ESMT F50L2G41XA clone, which advertises itself as MT29F2G01ABAGD3W in the ONFI parameter page) silently returned data from the matching even block in plane 0.

Single-plane SPI-NANDs were not affected, which is why the bug only surfaced on the F50L2G41XA / MT29F2G01ABAGD parts: with FIP compression enabled the corrupted bytes from plane 1 propagate into the XZ stream and BL2 dies with

  ERROR: xz: xz_dec_run() failed (err = 7)      # XZ_DATA_ERROR
  ERROR: Failed to decompress image (err=-5)
  ERROR: BL2: Failure in post image load handling (-5)

Drop the offending assignment; the per-detection-path setters already choose the right nb_planes for every part in the table.